### PR TITLE
Correct autofill value for new password fields

### DIFF
--- a/server/views/partials/admin/dialog/create_user.hbs
+++ b/server/views/partials/admin/dialog/create_user.hbs
@@ -26,6 +26,7 @@
         type="password"
         placeholder="Password..."
         hx-preserve="true"
+        autocomplete="new-password"
       />
       {{#if errors.password}}<p class="error">{{errors.password}}</p>{{/if}}
     </label>

--- a/server/views/partials/reset_password/new_password_form.hbs
+++ b/server/views/partials/reset_password/new_password_form.hbs
@@ -14,7 +14,8 @@
       type="password" 
       placeholder="New password..."
       hx-preserve="true"
-      required 
+      required
+      autocomplete="new-password"
     />
     {{#if errors.new_password}}<p class="error">{{errors.new_password}}</p>{{/if}}
   </label>
@@ -26,7 +27,8 @@
       type="password" 
       placeholder="Repeat password..."
       hx-preserve="true"
-      required 
+      required
+      autocomplete="new-password"
     />
     {{#if errors.repeat_password}}<p class="error">{{errors.repeat_password}}</p>{{/if}}
   </label>

--- a/server/views/partials/settings/change_password.hbs
+++ b/server/views/partials/settings/change_password.hbs
@@ -30,6 +30,7 @@
           type="password" 
           placeholder="New password..."
           hx-preserve="true"
+          autocomplete="new-password"
         />
         {{#if errors.newpassword}}<p class="error">{{errors.newpassword}}</p>{{/if}}
       </label>

--- a/server/views/partials/shortener.hbs
+++ b/server/views/partials/shortener.hbs
@@ -104,7 +104,7 @@
             name="password" 
             placeholder="Password..." 
             hx-preserve="true" 
-            autocomplete="off" 
+            autocomplete="new-password"
           />
           {{#if errors.password}}<p class="error">{{errors.password}}</p>{{/if}}
         </label>


### PR DESCRIPTION
Added "new-password" value for autofill where relevant. This avoids Firefox filling link password field with user password.

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-new-password